### PR TITLE
Fix wrong composer package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WeChatServiceAccount
 
 ```bash
-composer require socialiteproviders/wechatserviceaccount
+composer require socialiteproviders/wechat-service-account
 ```
 
 ## Installation & Basic Usage


### PR DESCRIPTION
For: https://github.com/SocialiteProviders/website/issues/50

Fix:
`socialiteproviders/wechatserviceaccount` does not exist, it should be `socialiteproviders/wechat-service-account`.